### PR TITLE
Support HTTPS endpoints

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -35,7 +35,7 @@ To generate your personal **API token** for your site, go to `Account` -> `My pr
 All requests to the Voog API are done through the `Voog::Client` class, which takes two parameters: site host and API token.
 
 ```ruby
-client = Voog::Client.new('example.com', 'afcf30182aecfc8155d390d7d4552d14')
+client = Voog::Client.new('example.com', 'afcf30182aecfc8155d390d7d4552d14', protocol: :http, raise_on_error: false)
 ```
 
 Making an API request is as simple as calling a single method on the client:
@@ -55,3 +55,8 @@ puts layout.title
 puts layout[:title]
 # => "Front page"
 ```
+
+### Optional parameters for client
+
+* `protocol` - endpoint protocol (`http` or `https` default is `http`).
+* `raise_on_error` - interrupts program with error (`Faraday::Error`) when request response code is between `400` and `600` (default is `false`).

--- a/lib/voog_api/api/articles.rb
+++ b/lib/voog_api/api/articles.rb
@@ -34,14 +34,14 @@ module Voog
 
       # Update/create a key in article data field
       #
-      # @params id [String] key in data field
+      # @param id [String] key in data field
       def update_article_data(article_id, id, data)
         put "articles/#{article_id}/data/#{id}", {value: data}
       end
 
       # Delete a key from article data field
       #
-      # @params id [String] key in data field
+      # @param id [String] key in data field
       def delete_article_data(article_id, id)
         delete "articles/#{article_id}/data/#{id}"
       end

--- a/lib/voog_api/api/pages.rb
+++ b/lib/voog_api/api/pages.rb
@@ -34,14 +34,14 @@ module Voog
 
       # Update/create a key in page data field
       #
-      # @params id [String] key in data field
+      # @param id [String] key in data field
       def update_page_data(page_id, id, data)
         put "pages/#{page_id}/data/#{id}", {value: data}
       end
 
       # Delete a key from page data field
       #
-      # @params id [String] key in data field
+      # @param id [String] key in data field
       def delete_page_data(page_id, id)
         delete "pages/#{page_id}/data/#{id}"
       end

--- a/lib/voog_api/api/site.rb
+++ b/lib/voog_api/api/site.rb
@@ -19,14 +19,14 @@ module Voog
 
       # Update/create a key in site data field
       #
-      # @params id [String] key in data field
+      # @param id [String] key in data field
       def update_site_data(id, data)
         put "site/data/#{id}", {value: data}
       end
 
       # Delete a key from site data field
       #
-      # @params id [String] key in data field
+      # @param id [String] key in data field
       def delete_site_data(id)
         delete "site/data/#{id}"
       end

--- a/lib/voog_api/client.rb
+++ b/lib/voog_api/client.rb
@@ -47,10 +47,19 @@ module Voog
 
     attr_reader :api_token, :host
 
+    # Initialize Voog API client.
+    #
+    # @param host [String] a Voog site host.
+    # @param api_token [String] a Voog site API token.
+    # @option options [String] :protocol endpoint protocol ("http" or "https"). Defaults to "http".
+    # @option options [Boolean] :raise_on_error interrupts program with error ("Faraday::Error") when request response code is between "400" and "600" (default is "false").
+    # @example Initialize client
+    #   client = Voog::Client.new('example.com', 'afcf30182aecfc8155d390d7d4552d14', protocol: :http, raise_on_error: false)
     def initialize(host = Voog.host, api_token = Voog.api_token, options = {})
       @host = host
       @api_token = api_token
       @options = options
+      @protocol = options[:protocol].to_s.downcase == 'https' ? 'https' : 'http'
       @raise_on_error = options.fetch(:raise_on_error, true)
     end
 
@@ -79,7 +88,7 @@ module Voog
     end
     
     def api_endpoint
-      "http://#{host}/admin/api"
+      "#{@protocol}://#{host}/admin/api"
     end
     
     def agent


### PR DESCRIPTION
Allow to set API endpoint protocol to HTTPS.

Example usage:
```ruby
client = Voog::Client.new('example.com', 'afcf30182aecfc8155d390d7d4552d14', protocol: :https)
```

See also #5.