### PR TITLE
Added auto pagination option for listing endpoints

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -35,7 +35,7 @@ To generate your personal **API token** for your site, go to `Account` -> `My pr
 All requests to the Voog API are done through the `Voog::Client` class, which takes two parameters: site host and API token.
 
 ```ruby
-client = Voog::Client.new('example.com', 'afcf30182aecfc8155d390d7d4552d14', protocol: :http, raise_on_error: false)
+client = Voog::Client.new('example.com', 'afcf30182aecfc8155d390d7d4552d14', protocol: :http, auto_paginate: true, raise_on_error: false)
 ```
 
 Making an API request is as simple as calling a single method on the client:
@@ -59,4 +59,6 @@ puts layout[:title]
 ### Optional parameters for client
 
 * `protocol` - endpoint protocol (`http` or `https` default is `http`).
+* `auto_paginate` - enable auto pagination for list requests. Defaults to `false`.
+* `per_page` - set default `per_page` value for list requests. Defaults to `nil` (API default is `50`).
 * `raise_on_error` - interrupts program with error (`Faraday::Error`) when request response code is between `400` and `600` (default is `false`).

--- a/lib/voog_api.rb
+++ b/lib/voog_api.rb
@@ -5,7 +5,7 @@ module Voog
 
   class << self
     
-    attr_accessor :host, :api_token
+    attr_accessor :host, :api_token, :auto_paginate, :per_page
 
     def client(options = {})
       unless host.nil? && api_token.nil?

--- a/lib/voog_api/api/articles.rb
+++ b/lib/voog_api/api/articles.rb
@@ -4,7 +4,7 @@ module Voog
 
       # List articles
       def articles(params = {})
-        get 'articles', {query: params}
+        paginate 'articles', {query: params}
       end
 
       # Get a single article

--- a/lib/voog_api/api/assets.rb
+++ b/lib/voog_api/api/assets.rb
@@ -4,7 +4,7 @@ module Voog
 
       # List assets
       def assets(params = {})
-        get 'assets', {query: params}
+        paginate 'assets', {query: params}
       end
 
       # Get a single asset

--- a/lib/voog_api/api/comments.rb
+++ b/lib/voog_api/api/comments.rb
@@ -4,7 +4,7 @@ module Voog
 
       # List article comments
       def comments(article_id, params = {})
-        get "articles/#{article_id}/comments", {query: params}
+        paginate "articles/#{article_id}/comments", {query: params}
       end
 
       # Get a single comment for article

--- a/lib/voog_api/api/content_partials.rb
+++ b/lib/voog_api/api/content_partials.rb
@@ -4,7 +4,7 @@ module Voog
 
       # List content partials contents
       def content_partials(params = {})
-        get 'content_partials', {query: params}
+        paginate 'content_partials', {query: params}
       end
 
       # Get a single content partial content

--- a/lib/voog_api/api/contents.rb
+++ b/lib/voog_api/api/contents.rb
@@ -11,7 +11,7 @@ module Voog
 
       # List contents
       def contents(parent_name, parent_id, params = {})
-        get "#{parent_name}/#{parent_id}/contents", {query: params}
+        paginate "#{parent_name}/#{parent_id}/contents", {query: params}
       end
 
       # Get a single content

--- a/lib/voog_api/api/element_definitions.rb
+++ b/lib/voog_api/api/element_definitions.rb
@@ -4,7 +4,7 @@ module Voog
 
       # List element_definitions
       def element_definitions(params = {})
-        get 'element_definitions', {query: params}
+        paginate 'element_definitions', {query: params}
       end
 
       # Get a single element_definition

--- a/lib/voog_api/api/elements.rb
+++ b/lib/voog_api/api/elements.rb
@@ -4,7 +4,7 @@ module Voog
 
       # List elements
       def elements(params = {})
-        get 'elements', {query: params}
+        paginate 'elements', {query: params}
       end
 
       # Get a single element

--- a/lib/voog_api/api/forms.rb
+++ b/lib/voog_api/api/forms.rb
@@ -4,7 +4,7 @@ module Voog
 
       # List forms
       def forms(params = {})
-        get 'forms', {query: params}
+        paginate 'forms', {query: params}
       end
 
       # Get a single form

--- a/lib/voog_api/api/languages.rb
+++ b/lib/voog_api/api/languages.rb
@@ -4,7 +4,7 @@ module Voog
 
       # List languages
       def languages(params = {})
-        get 'languages', {query: params}
+        paginate 'languages', {query: params}
       end
 
       # Get a single language

--- a/lib/voog_api/api/layout_assets.rb
+++ b/lib/voog_api/api/layout_assets.rb
@@ -4,7 +4,7 @@ module Voog
       
       # List layouts assets
       def layout_assets(params = {})
-        get 'layout_assets', {query: params}
+        paginate 'layout_assets', {query: params}
       end
 
       # Get a single layout asset

--- a/lib/voog_api/api/layouts.rb
+++ b/lib/voog_api/api/layouts.rb
@@ -4,7 +4,7 @@ module Voog
 
       # List layouts
       def layouts(params = {})
-        get 'layouts', {query: params}
+        paginate 'layouts', {query: params}
       end
 
       # Get a single layout

--- a/lib/voog_api/api/media_sets.rb
+++ b/lib/voog_api/api/media_sets.rb
@@ -4,7 +4,7 @@ module Voog
 
       # List media_sets
       def media_sets(params = {})
-        get 'media_sets', {query: params}
+        paginate 'media_sets', {query: params}
       end
 
       # Get a single media_set

--- a/lib/voog_api/api/nodes.rb
+++ b/lib/voog_api/api/nodes.rb
@@ -4,7 +4,7 @@ module Voog
 
       # List nodes
       def nodes(params = {})
-        get 'nodes', {query: params}
+        paginate 'nodes', {query: params}
       end
 
       # Get a single node

--- a/lib/voog_api/api/pages.rb
+++ b/lib/voog_api/api/pages.rb
@@ -4,7 +4,7 @@ module Voog
 
       # List pages
       def pages(params = {})
-        get 'pages', {query: params}
+        paginate 'pages', {query: params}
       end
 
       # Get a single page

--- a/lib/voog_api/api/people.rb
+++ b/lib/voog_api/api/people.rb
@@ -4,7 +4,7 @@ module Voog
 
       # List people
       def people(params = {})
-        get 'people', {query: params}
+        paginate 'people', {query: params}
       end
 
       # Get a single person

--- a/lib/voog_api/api/tags.rb
+++ b/lib/voog_api/api/tags.rb
@@ -4,7 +4,7 @@ module Voog
 
       # List tags
       def tags(params = {})
-        get 'tags', {query: params}
+        paginate 'tags', {query: params}
       end
 
       # Get a single tag

--- a/lib/voog_api/api/texts.rb
+++ b/lib/voog_api/api/texts.rb
@@ -4,7 +4,7 @@ module Voog
 
       # List text contents
       def texts(params = {})
-        get 'texts', {query: params}
+        paginate 'texts', {query: params}
       end
 
       # Get a single text content

--- a/lib/voog_api/api/tickets.rb
+++ b/lib/voog_api/api/tickets.rb
@@ -4,7 +4,7 @@ module Voog
 
       # List form tickets
       def tickets(form_id, params = {})
-        get "forms/#{form_id}/tickets", {query: params}
+        paginate "forms/#{form_id}/tickets", {query: params}
       end
 
       # Get a single ticket for form


### PR DESCRIPTION
Allow allow to set default `per_page` value.

Example usage:

```ruby
  client = Voog::Client.new('example.com', 'afcf30182aecfc8155d390d7d4552d14', auto_paginate: true, per_page: 250)
```

See also #3

Read more: http://www.voog.com/developers/api/basics/paginati