### PR TITLE
Update gems

### DIFF
--- a/lib/voog_api/client.rb
+++ b/lib/voog_api/client.rb
@@ -81,7 +81,7 @@ module Voog
     def get(url, options = {})
       request :get, url, nil, options
     end
-    
+
     def post(url, data, options = {})
       request :post, url, data, options
     end
@@ -101,7 +101,7 @@ module Voog
     def head(url, options = {})
       request :head, url, nil, options
     end
-    
+
     def api_endpoint
       "#{host_with_protocol}/admin/api".freeze
     end
@@ -109,7 +109,7 @@ module Voog
     def host_with_protocol
       "#{protocol}://#{host}".freeze
     end
-    
+
     def agent
       @agent ||= Sawyer::Agent.new(api_endpoint, sawyer_options) do |http|
         http.headers[:content_type] = 'application/json'
@@ -129,7 +129,7 @@ module Voog
         faraday.headers[:user_agent] = 'Voog.rb Ruby wrapper'
       end
     end
-    
+
     def last_response
       @last_response
     end
@@ -162,16 +162,16 @@ module Voog
       end
 
       data
-     end
+    end
 
     private
-    
+
     def request(method, path, data, options = {})
       multipart = options.fetch(:multipart, false) && (method == :post)
 
       @last_response = response = multipart ? \
         multipart_agent.post("#{api_endpoint}/#{path}", data) : \
-        agent.call(method, URI.encode(path.to_s), data, options.dup)
+        agent.call(method, URI.parse(path.to_s), data, options.dup)
 
       raise Voog::MovedPermanently.new(response, host_with_protocol) if response.status == 301
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,12 @@
 require 'voog_api'
 require 'webmock/rspec'
+require 'pathname'
 
 WebMock.disable_net_connect!
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
-  
+
   config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
@@ -30,14 +31,16 @@ def fixture(file)
 end
 
 def request_fixture(method, path, options = {})
-  request = ({
-    headers: {'X-API-TOKEN' => 'afcf30182aecfc8155d390d7d4552d14'}
-  }).merge(options.fetch(:request, {}))
-  
+  request = {
+    headers: {
+      'X-API-TOKEN' => 'afcf30182aecfc8155d390d7d4552d14'
+    }
+  }
+
   response = ({headers: {'Content-Type' => 'application/json'}}).tap { |response|
     response[:body] = fixture(options[:fixture]) if options.has_key?(:fixture)
   }.merge(options.fetch(:response, {}))
-  
+
   stub_request(method, voog_url(path)).with(request).to_return(response)
 end
 

--- a/spec/voog_api/api/search_spec.rb
+++ b/spec/voog_api/api/search_spec.rb
@@ -6,7 +6,7 @@ describe Voog::API::Search do
 
   describe '#people' do
     before do
-      request_fixture(:get, 'search', request: {q: 'any kind of content'}, fixture: 'search/search')
+      request_fixture(:get, 'search', request: {query: {q: 'any kind of content'}}, fixture: 'search/search')
     end
 
     it 'returns a list of search results' do

--- a/voog_api.gemspec
+++ b/voog_api.gemspec
@@ -17,12 +17,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'guard-rspec', '~> 4.2.0'
   spec.add_development_dependency 'rspec', '~> 2.14.1'
-  spec.add_development_dependency 'webmock', '1.16.0'
+  spec.add_development_dependency 'webmock', '~> 3.18'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'listen', '~> 3.0.8'
 
-  spec.add_dependency 'sawyer', '~> 0.5.4'
+  spec.add_dependency 'sawyer', '~> 0.9'
 end

--- a/voog_api.gemspec
+++ b/voog_api.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'guard-rspec', '~> 4.2.0'
-  spec.add_development_dependency 'rspec', '~> 2.14.1'
+  spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'webmock', '~> 3.18'
   spec.add_development_dependency 'rake'
 


### PR DESCRIPTION
Update dependencies to ensure better compatibility with newer Ruby versions. Tested with Ruby 2.6.8 and Ruby 3.0.2, both of which should be working as a result.