### PR TITLE
Update API endpoints

### DIFF
--- a/lib/voog_api/api/buy_buttons.rb
+++ b/lib/voog_api/api/buy_buttons.rb
@@ -1,0 +1,30 @@
+module Voog
+  class API
+    # Voog Buy Buttons API methods.
+    #
+    # @see https://www.voog.com/developers/api/resources/buy_buttons
+    module BuyButtons
+
+      # List buy_buttons
+      #
+      # @see https://www.voog.com/developers/api/resources/buy_buttons#get_buy_buttons
+      def buy_buttons(params = {})
+        paginate 'buy_buttons', {query: params}
+      end
+
+      # Get a single buy_button
+      #
+      # @see https://www.voog.com/developers/api/resources/buy_buttons#get_buy_button
+      def buy_button(id, params = {})
+        get "buy_buttons/#{id}", {query: params}
+      end
+
+      # Update a buy_button
+      #
+      # @see https://www.voog.com/developers/api/resources/buy_buttons#update_buy_button
+      def update_buy_button(id, data)
+        put "buy_buttons/#{id}", data
+      end
+    end
+  end
+end

--- a/lib/voog_api/api/product_widgets.rb
+++ b/lib/voog_api/api/product_widgets.rb
@@ -1,0 +1,31 @@
+module Voog
+
+  class API
+    # Voog Product Widgets API methods.
+    #
+    # @see https://www.voog.com/developers/api/resources/product_widgets
+    module ProductWidgets
+
+      # List product_widgets
+      #
+      # @see https://www.voog.com/developers/api/resources/product_widgets#get_product_widgets
+      def product_widgets(params = {})
+        paginate 'product_widgets', {query: params}
+      end
+
+      # Get a single product_widget
+      #
+      # @see https://www.voog.com/developers/api/resources/product_widgets#get_product_widget
+      def product_widget(id, params = {})
+        get "product_widgets/#{id}", {query: params}
+      end
+
+      # Update a product_widget
+      #
+      # @see https://www.voog.com/developers/api/resources/product_widgets#update_product_widget
+      def update_product_widget(id, data)
+        put "product_widgets/#{id}", data
+      end
+    end
+  end
+end

--- a/lib/voog_api/api/redirect_rules.rb
+++ b/lib/voog_api/api/redirect_rules.rb
@@ -1,0 +1,44 @@
+module Voog
+  class API
+    # Voog Redirect Rules API methods.
+    #
+    # @see https://www.voog.com/developers/api/resources/redirect_rules
+    module RedirectRules
+
+      # List redirect_rules
+      #
+      # @see https://www.voog.com/developers/api/resources/redirect_rules#get_redirect_rules
+      def redirect_rules(params = {})
+        paginate 'redirect_rules', {query: params}
+      end
+
+      # Get a single redirect_rule
+      #
+      # @see https://www.voog.com/developers/api/resources/redirect_rules#get_redirect_rule
+      def redirect_rule(id, params = {})
+        get "redirect_rules/#{id}", {query: params}
+      end
+
+      # Create a new redirect_rule
+      #
+      # @see https://www.voog.com/developers/api/resources/redirect_rules#create_redirect_rules
+      def create_redirect_rule(data)
+        post 'redirect_rules', data
+      end
+
+      # Update a redirect_rule
+      #
+      # @see https://www.voog.com/developers/api/resources/redirect_rules#update_redirect_rule
+      def update_redirect_rule(id, data)
+        put "redirect_rules/#{id}", data
+      end
+
+      # Delete a redirect_rule
+      #
+      # @see https://www.voog.com/developers/api/resources/redirect_rules#delete_redirect_rule
+      def delete_redirect_rule(id)
+        delete "redirect_rules/#{id}"
+      end
+    end
+  end
+end

--- a/lib/voog_api/client.rb
+++ b/lib/voog_api/client.rb
@@ -13,16 +13,17 @@ require 'voog_api/api/element_definitions'
 require 'voog_api/api/elements'
 require 'voog_api/api/forms'
 require 'voog_api/api/languages'
-require 'voog_api/api/layouts'
 require 'voog_api/api/layout_assets'
+require 'voog_api/api/layouts'
 require 'voog_api/api/media_sets'
 require 'voog_api/api/nodes'
-require 'voog_api/api/site'
 require 'voog_api/api/pages'
 require 'voog_api/api/people'
 require 'voog_api/api/product_widgets'
+require 'voog_api/api/redirect_rules'
 require 'voog_api/api/search'
 require 'voog_api/api/site_users'
+require 'voog_api/api/site'
 require 'voog_api/api/tags'
 require 'voog_api/api/texts'
 require 'voog_api/api/tickets'
@@ -46,13 +47,14 @@ module Voog
     include Voog::API::Elements
     include Voog::API::Forms
     include Voog::API::Languages
-    include Voog::API::Layouts
     include Voog::API::LayoutAssets
+    include Voog::API::Layouts
     include Voog::API::MediaSets
     include Voog::API::Nodes
     include Voog::API::Pages
     include Voog::API::People
     include Voog::API::ProductWidgets
+    include Voog::API::RedirectRules
     include Voog::API::Search
     include Voog::API::Site
     include Voog::API::SiteUsers

--- a/lib/voog_api/client.rb
+++ b/lib/voog_api/client.rb
@@ -20,6 +20,7 @@ require 'voog_api/api/nodes'
 require 'voog_api/api/site'
 require 'voog_api/api/pages'
 require 'voog_api/api/people'
+require 'voog_api/api/product_widgets'
 require 'voog_api/api/search'
 require 'voog_api/api/site_users'
 require 'voog_api/api/tags'
@@ -51,6 +52,7 @@ module Voog
     include Voog::API::Nodes
     include Voog::API::Pages
     include Voog::API::People
+    include Voog::API::ProductWidgets
     include Voog::API::Search
     include Voog::API::Site
     include Voog::API::SiteUsers

--- a/lib/voog_api/client.rb
+++ b/lib/voog_api/client.rb
@@ -5,6 +5,7 @@ require 'voog_api/error'
 
 require 'voog_api/api/articles'
 require 'voog_api/api/assets'
+require 'voog_api/api/buy_buttons'
 require 'voog_api/api/comments'
 require 'voog_api/api/content_partials'
 require 'voog_api/api/contents'
@@ -36,6 +37,7 @@ module Voog
 
     include Voog::API::Articles
     include Voog::API::Assets
+    include Voog::API::BuyButtons
     include Voog::API::Comments
     include Voog::API::ContentPartials
     include Voog::API::Contents

--- a/spec/fixtures/buy_buttons/buy_button.json
+++ b/spec/fixtures/buy_buttons/buy_button.json
@@ -1,0 +1,38 @@
+{
+  "id": 2,
+  "created_at": "2023-11-17T12:56:36.000Z",
+  "updated_at": "2023-11-17T12:56:36.000Z",
+  "settings": {
+    "title": "Add to cart",
+    "button_style": "with_price"
+  },
+  "url": "http://voog.test/admin/api/buy_buttons/2",
+  "content": {
+    "id": 2,
+    "name": "body",
+    "created_at": "2023-11-17T12:56:36.000Z",
+    "updated_at": "2023-11-17T12:56:36.000Z",
+    "position": 1,
+    "url": "http://voog.test/admin/api/pages/1/contents/2"
+  },
+  "parent": {
+    "id": 1,
+    "title": "Home",
+    "created_at": "2023-11-17T12:55:36.000Z",
+    "updated_at": "2023-11-17T12:55:36.000Z",
+    "type": "page",
+    "url": "http://voog.test/admin/api/pages/1"
+  },
+  "product": {
+    "id": 1,
+    "name": "Product",
+    "price": "100.0",
+    "status": "live",
+    "created_at": "2023-11-17T12:55:36.000Z",
+    "updated_at": "2023-11-17T12:55:36.000Z",
+    "sku": "product-sku",
+    "uses_variants": false,
+    "tax_rate": "20.0",
+    "in_stock": true
+  }
+}

--- a/spec/fixtures/buy_buttons/buy_buttons.json
+++ b/spec/fixtures/buy_buttons/buy_buttons.json
@@ -1,0 +1,78 @@
+[
+  {
+    "id": 1,
+    "created_at": "2023-11-17T12:55:36.000Z",
+    "updated_at": "2023-11-17T12:55:36.000Z",
+    "settings": {
+      "title": "Add to cart",
+      "button_style": "with_price"
+    },
+    "url": "http://voog.test/admin/api/buy_buttons/1",
+    "content": {
+      "id": 1,
+      "name": "body",
+      "created_at": "2023-11-17T12:55:36.000Z",
+      "updated_at": "2023-11-17T12:55:36.000Z",
+      "position": 1,
+      "url": "http://voog.test/admin/api/pages/1/contents/1"
+    },
+    "parent": {
+      "id": 1,
+      "title": "Home",
+      "created_at": "2023-11-17T12:55:36.000Z",
+      "updated_at": "2023-11-17T12:55:36.000Z",
+      "type": "page",
+      "url": "http://voog.test/admin/api/pages/1"
+    },
+    "product": {
+      "id": 1,
+      "name": "Product",
+      "price": "100.0",
+      "status": "live",
+      "created_at": "2023-11-17T12:55:36.000Z",
+      "updated_at": "2023-11-17T12:55:36.000Z",
+      "sku": "product-sku",
+      "uses_variants": false,
+      "tax_rate": "20.0",
+      "in_stock": true
+    }
+  },
+  {
+    "id": 2,
+    "created_at": "2023-11-17T12:56:36.000Z",
+    "updated_at": "2023-11-17T12:56:36.000Z",
+    "settings": {
+      "title": "Add to cart",
+      "button_style": "with_price"
+    },
+    "url": "http://voog.test/admin/api/buy_buttons/2",
+    "content": {
+      "id": 2,
+      "name": "body",
+      "created_at": "2023-11-17T12:56:36.000Z",
+      "updated_at": "2023-11-17T12:56:36.000Z",
+      "position": 1,
+      "url": "http://voog.test/admin/api/pages/1/contents/2"
+    },
+    "parent": {
+      "id": 1,
+      "title": "Home",
+      "created_at": "2023-11-17T12:55:36.000Z",
+      "updated_at": "2023-11-17T12:55:36.000Z",
+      "type": "page",
+      "url": "http://voog.test/admin/api/pages/1"
+    },
+    "product": {
+      "id": 1,
+      "name": "Product",
+      "price": "100.0",
+      "status": "live",
+      "created_at": "2023-11-17T12:55:36.000Z",
+      "updated_at": "2023-11-17T12:55:36.000Z",
+      "sku": "product-sku",
+      "uses_variants": false,
+      "tax_rate": "20.0",
+      "in_stock": true
+    }
+  }
+]

--- a/spec/fixtures/product_widgets/product_widget.json
+++ b/spec/fixtures/product_widgets/product_widget.json
@@ -1,0 +1,41 @@
+{
+  "id": 2,
+  "created_at": "2023-11-17T13:26:47.000Z",
+  "updated_at": "2023-11-17T13:26:47.000Z",
+  "content_settings": {
+    "category_ids": [],
+    "sort_order": "created_at-desc"
+  },
+  "design_settings": {
+    "layout": "grid",
+    "columns": 3,
+    "item_width": 300,
+    "item_height": 600,
+    "mask_content_overflow": true,
+    "show_navigation_buttons": true,
+    "mobile_columns": 2,
+    "show_cart_button": true,
+    "show_price": true,
+    "show_product_filters": true,
+    "product_count": 56,
+    "show_discount_label": false,
+    "show_discount_percentage": false
+  },
+  "url": "http://voog.test/admin/api/product_widgets/2",
+  "content": {
+    "id": 2,
+    "name": "body",
+    "created_at": "2023-11-17T12:56:36.000Z",
+    "updated_at": "2023-11-17T12:56:36.000Z",
+    "position": 1,
+    "url": "http://voog.test/admin/api/pages/1/contents/2"
+  },
+  "parent": {
+    "id": 1,
+    "title": "Home",
+    "created_at": "2023-11-17T12:55:36.000Z",
+    "updated_at": "2023-11-17T12:55:36.000Z",
+    "type": "page",
+    "url": "http://voog.test/admin/api/pages/1"
+  }
+}

--- a/spec/fixtures/product_widgets/product_widgets.json
+++ b/spec/fixtures/product_widgets/product_widgets.json
@@ -1,0 +1,84 @@
+[
+  {
+    "id": 1,
+    "created_at": "2023-11-17T13:25:47.000Z",
+    "updated_at": "2023-11-17T13:25:47.000Z",
+    "content_settings": {
+      "category_ids": [],
+      "sort_order": "created_at-desc"
+    },
+    "design_settings": {
+      "layout": "grid",
+      "columns": 3,
+      "item_width": 300,
+      "item_height": 600,
+      "mask_content_overflow": true,
+      "show_navigation_buttons": true,
+      "mobile_columns": 2,
+      "show_cart_button": true,
+      "show_price": true,
+      "show_product_filters": true,
+      "product_count": 56,
+      "show_discount_label": false,
+      "show_discount_percentage": false
+    },
+    "url": "http://voog.test/admin/api/product_widgets/1",
+    "content": {
+      "id": 1,
+      "name": "body",
+      "created_at": "2023-11-17T12:55:36.000Z",
+      "updated_at": "2023-11-17T12:55:36.000Z",
+      "position": 1,
+      "url": "http://voog.test/admin/api/pages/1/contents/1"
+    },
+    "parent": {
+      "id": 1,
+      "title": "Home",
+      "created_at": "2023-11-17T12:55:36.000Z",
+      "updated_at": "2023-11-17T12:55:36.000Z",
+      "type": "page",
+      "url": "http://voog.test/admin/api/pages/1"
+    }
+  },
+  {
+    "id": 2,
+    "created_at": "2023-11-17T13:26:47.000Z",
+    "updated_at": "2023-11-17T13:26:47.000Z",
+    "content_settings": {
+      "category_ids": [],
+      "sort_order": "created_at-desc"
+    },
+    "design_settings": {
+      "layout": "grid",
+      "columns": 3,
+      "item_width": 300,
+      "item_height": 600,
+      "mask_content_overflow": true,
+      "show_navigation_buttons": true,
+      "mobile_columns": 2,
+      "show_cart_button": true,
+      "show_price": true,
+      "show_product_filters": true,
+      "product_count": 56,
+      "show_discount_label": false,
+      "show_discount_percentage": false
+    },
+    "url": "http://voog.test/admin/api/product_widgets/2",
+    "content": {
+      "id": 2,
+      "name": "body",
+      "created_at": "2023-11-17T12:56:36.000Z",
+      "updated_at": "2023-11-17T12:56:36.000Z",
+      "position": 1,
+      "url": "http://voog.test/admin/api/pages/1/contents/2"
+    },
+    "parent": {
+      "id": 1,
+      "title": "Home",
+      "created_at": "2023-11-17T12:55:36.000Z",
+      "updated_at": "2023-11-17T12:55:36.000Z",
+      "type": "page",
+      "url": "http://voog.test/admin/api/pages/1"
+    }
+  }
+]

--- a/spec/fixtures/redirect_rules/redirect_rule.json
+++ b/spec/fixtures/redirect_rules/redirect_rule.json
@@ -1,0 +1,12 @@
+{
+  "id": 2,
+  "active": true,
+  "regexp": false,
+  "source": "/other-page",
+  "destination": "/new-other-page",
+  "redirect_type": 301,
+  "complexity": 1005,
+  "created_at": "2023-11-24T10:23:49.000Z",
+  "updated_at": "2023-11-24T10:23:49.000Z",
+  "url": "http://voog.test/admin/api/redirect_rules/2"
+}

--- a/spec/fixtures/redirect_rules/redirect_rules.json
+++ b/spec/fixtures/redirect_rules/redirect_rules.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": 1,
+    "active": true,
+    "regexp": false,
+    "source": "/page",
+    "destination": "/new-page",
+    "redirect_type": 301,
+    "complexity": 1005,
+    "created_at": "2023-11-24T10:23:04.000Z",
+    "updated_at": "2023-11-24T10:23:04.000Z",
+    "url": "http://voog.test/admin/api/redirect_rules/1"
+  },
+  {
+    "id": 2,
+    "active": true,
+    "regexp": false,
+    "source": "/other-page",
+    "destination": "/new-other-page",
+    "redirect_type": 301,
+    "complexity": 1005,
+    "created_at": "2023-11-24T10:23:49.000Z",
+    "updated_at": "2023-11-24T10:23:49.000Z",
+    "url": "http://voog.test/admin/api/redirect_rules/2"
+  }
+]

--- a/spec/voog_api/api/buy_buttons_spec.rb
+++ b/spec/voog_api/api/buy_buttons_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe Voog::API::BuyButtons do
+  let(:client) { voog_client }
+
+  describe '#buy_buttons' do
+    before do
+      request_fixture(:get, 'buy_buttons', fixture: 'buy_buttons/buy_buttons')
+    end
+
+    it 'returns a list of buy_buttons' do
+      expect(client.buy_buttons.length).to eql(2)
+    end
+  end
+
+  describe '#buy_button' do
+    before do
+      request_fixture(:get, 'buy_buttons/2', fixture: 'buy_buttons/buy_button')
+    end
+
+    it 'returns a single buy_button' do
+      expect(client.buy_button(2).settings.title).to eq('Add to cart')
+    end
+
+    it 'returns a buy_button with the same id as in the request' do
+      expect(client.buy_button(2).id).to eq(2)
+    end
+  end
+
+  describe '#update_buy_button' do
+    let(:new_title) { 'New title' }
+
+    before do
+      request_fixture(
+        :put,
+        'buy_buttons/2',
+        request: {
+          body: {
+            settings: {
+              title: new_title
+            }
+          }
+        },
+        response: {
+          body: "{\"id\": 2, \"settings\": {\"title\": \"#{new_title}\"}}"
+        }
+      )
+    end
+
+    it 'responds with new title' do
+      expect(
+        client.update_buy_button(2, settings: {title: new_title}).settings.title
+      ).to eq(new_title)
+    end
+  end
+end

--- a/spec/voog_api/api/product_widgets_spec.rb
+++ b/spec/voog_api/api/product_widgets_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe Voog::API::ProductWidgets do
+  let(:client) { voog_client }
+
+  describe '#product_widgets' do
+    before do
+      request_fixture(:get, 'product_widgets', fixture: 'product_widgets/product_widgets')
+    end
+
+    it 'returns a list of product_widgets' do
+      expect(client.product_widgets.length).to eql(2)
+    end
+  end
+
+  describe '#product_widget' do
+    before do
+      request_fixture(:get, 'product_widgets/2', fixture: 'product_widgets/product_widget')
+    end
+
+    it 'returns a single product_widget' do
+      expect(client.product_widget(2).design_settings.layout).to eq('grid')
+    end
+
+    it 'returns a product_widget with the same id as in the request' do
+      expect(client.product_widget(2).id).to eq(2)
+    end
+  end
+
+  describe '#update_product_widget' do
+    let(:new_layout) { 'list' }
+
+    before do
+      request_fixture(
+        :put,
+        'product_widgets/2',
+        request: {
+          body: {
+            design_settings: {
+              layout: new_layout
+            }
+          }
+        },
+        response: {
+          body: "{\"id\": 2, \"design_settings\": {\"layout\": \"#{new_layout}\"}}"
+        }
+      )
+    end
+
+    it 'responds with new layout' do
+      expect(
+        client.update_product_widget(2, design_settings: {layout: new_layout}).design_settings.layout
+      ).to eq(new_layout)
+    end
+  end
+end

--- a/spec/voog_api/api/redirect_rules_spec.rb
+++ b/spec/voog_api/api/redirect_rules_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+describe Voog::API::RedirectRules do
+
+  let(:client) { voog_client }
+
+  describe '#redirect_rules' do
+    before do
+      request_fixture(:get, 'redirect_rules', fixture: 'redirect_rules/redirect_rules')
+    end
+
+    it 'returns a list of redirect_rules' do
+      expect(client.redirect_rules.length).to eql(2)
+    end
+  end
+
+  describe '#redirect_rule' do
+    before do
+      request_fixture(:get, 'redirect_rules/2', fixture: 'redirect_rules/redirect_rule')
+    end
+
+    it 'returns a single redirect_rule' do
+      expect(client.redirect_rule(2).source).to eq('/other-page')
+    end
+
+    it 'returns a redirect_rule with the same id as in the request' do
+      expect(client.redirect_rule(2).id).to eq(2)
+    end
+  end
+
+  describe '#delete_redirect_rule' do
+    before do
+      request_fixture(:delete, 'redirect_rules/2')
+    end
+
+    it 'calls delete method on redirect_rule' do
+      client.delete_redirect_rule(2)
+
+      assert_requested :delete, 'http://voog.test/admin/api/redirect_rules/2'
+    end
+  end
+
+  describe '#update_redirect_rule' do
+    let(:new_source) { '/new-source' }
+    before do
+      request_fixture(
+        :put,
+        'redirect_rules/2',
+        request: {
+          body: {source: new_source}
+        },
+        response: {
+          body: "{\"id\": 2, \"source\": \"#{new_source}\"}"
+        }
+      )
+    end
+
+    it 'responds with new source' do
+      expect(client.update_redirect_rule(2, source: new_source).source).to eq(new_source)
+    end
+  end
+end


### PR DESCRIPTION
Add missing non-ecommerce related API endpoints to `voog_api` gem. This includes `buy_buttons`, `product_widgets` and  `redirect_rules` API endpoints.

https://www.voog.com/developers/api/resources/buy_buttons
https://www.voog.com/developers/api/resources/product_widgets
https://www.voog.com/developers/api/resources/redirect_rules