### PR TITLE
Add 'faraday' as a gem dependency

### DIFF
--- a/lib/voog_api/client.rb
+++ b/lib/voog_api/client.rb
@@ -1,5 +1,10 @@
 require 'json'
 require 'sawyer'
+require 'faraday'
+
+if ::Gem::Requirement.new('>= 2.0').satisfied_by?(::Gem::Version.new(Faraday::VERSION))
+  require 'faraday/multipart'
+end
 
 require 'voog_api/error'
 

--- a/lib/voog_api/version.rb
+++ b/lib/voog_api/version.rb
@@ -1,3 +1,3 @@
 module Voog
-  VERSION = '0.0.14'
+  VERSION = '0.0.15'
 end

--- a/voog_api.gemspec
+++ b/voog_api.gemspec
@@ -23,4 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
 
   spec.add_dependency 'sawyer', '~> 0.9'
+  spec.add_dependency 'faraday', '>= 0.9', '< 3'
+  spec.add_dependency 'faraday-multipart', '> 0' if RUBY_VERSION >= '2.4'
 end


### PR DESCRIPTION
Add [faraday](https://github.com/lostisland/faraday) as a gem dependency.

Also add '[faraday-multipart](https://github.com/lostisland/faraday-multipart)' (extracted from 'faraday' since version 2.0) as a dependency when running Ruby 2.4 or newer. 

So we can support both older and newer versions of 'faraday'.